### PR TITLE
Fixed test on Windows

### DIFF
--- a/.github/workflows/core_test_linux.yml
+++ b/.github/workflows/core_test_linux.yml
@@ -1,4 +1,4 @@
-name: C/C++ Core Test CI
+name: C/C++ Core Test CI ran on Linux
 
 on:
   push:
@@ -20,11 +20,11 @@ jobs:
         run: |
           cd ${{ github.workspace }}/../../_temp
           cmake -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9 -DCMAKE_MAKE_PROGRAM=make ${{ github.workspace }}/TabsPls_Test
-          cmake --build .
+          cmake --build . --config Release
           
       - name: dir
         run: find ${{ github.workspace }}/../../_temp
       - name: Run CTest
         run: |
           cd ${{ github.workspace }}/../../_temp 
-          ctest -C Debug 
+          ctest -C Release

--- a/.github/workflows/core_test_windows.yml
+++ b/.github/workflows/core_test_windows.yml
@@ -1,0 +1,53 @@
+name: C/C++ Core Test ran on Windows
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set vcpkg's response file path used as part of cache's key.
+        uses: lukka/set-shell-env@master
+        with:
+          VCPKGRESPONSEFILE: ${{ github.workspace }}/TabsPls_Test/cmakeliststxt/vcpkg_x64-windows.txt
+
+      - name: dir
+        run: find $RUNNER_WORKSPACE
+        shell: bash
+      - name: Restore artifacts, or run vcpkg, build and cache artifacts
+        uses: lukka/run-vcpkg@main
+        id: runvcpkg
+        with:
+          vcpkgArguments: '@${{ env.VCPKGRESPONSEFILE }}'
+          vcpkgDirectory: '${{ github.workspace }}/TabsPls_Test/vcpkg'
+          # Ensure the cache key changes any time the content of the response file changes.
+          appendedCacheKey: ${{ hashFiles( env.VCPKGRESPONSEFILE ) }}
+
+      - name: Run CMake with MSBuild
+        uses: lukka/run-cmake@v2
+        id: runcmake
+        with:
+          cmakeListsOrSettingsJson: CMakeListsTxtBasic
+          cmakeListsTxtPath: '${{ github.workspace }}/TabsPls_Test/CMakeLists.txt'
+          cmakeGenerator: VS16Win64
+          cmakeBuildType: Release
+          useVcpkgToolchainFile: true
+      - name: Prints output of run-vcpkg's task
+        run: echo "root='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}', triplet='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_TRIPLET_OUT }}' "
+
+      - name: dir
+        run: find "${{ github.workspace }}/../../_temp"
+        shell: bash
+      - name: Run CTest
+        run: |
+          cd "${{ github.workspace }}/../../_temp"
+          ctest -C Release 

--- a/TabsPls_Test/CMakeLists.txt
+++ b/TabsPls_Test/CMakeLists.txt
@@ -38,7 +38,7 @@ target_compile_features(TabsPlsTest PUBLIC cxx_std_17)
 
 find_package(GTest)
 if(GTest_FOUND)
-	target_link_libraries(TabsPlsTest gtest)
+	target_link_libraries(TabsPlsTest GTest::gtest)
 endif()
 
 if(UNIX)

--- a/TabsPls_Test/gtest_main.cc
+++ b/TabsPls_Test/gtest_main.cc
@@ -46,7 +46,7 @@ void loop() { RUN_ALL_TESTS(); }
 
 #else
 
-GTEST_API_ int main(int argc, char **argv) {
+int main(int argc, char **argv) {
   printf("Running main() from %s\n", __FILE__);
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/TabsPls_Test/testCreateNewDirectory.cpp
+++ b/TabsPls_Test/testCreateNewDirectory.cpp
@@ -25,7 +25,7 @@ namespace CreateNewDirectoryTests
 	{
 		FakeFileSystem::AddDirectory({ "C:", "users" });
 
-		FileSystem::Op::CreateDirectory(*FileSystem::Directory::FromPath(FakeFileSystem::MergeUsingSeparator({"C:", "users"})), "//Jos" );
+		FileSystem::Op::CreateDirectory(*FileSystem::Directory::FromPath(FakeFileSystem::MergeUsingSeparator({"C:", "users"})), FileSystem::Separator() + FileSystem::Separator() + "Jos" );
 
 		EXPECT_TRUE(FileSystem::IsDirectory(FakeFileSystem::MergeUsingSeparator({ "C:", "users", "Jos" })));
 	}


### PR DESCRIPTION
this test was made with the assumption that a fake filesystem separator was always '/', which is incorrect on Windows. Now the platform's separator is used.