### PR TITLE
Fix mistake in applying the filter to newly inserted rows

### DIFF
--- a/TabsPls_Qt/LightSpeedFileExplorer/FileBrowserWidget.cpp
+++ b/TabsPls_Qt/LightSpeedFileExplorer/FileBrowserWidget.cpp
@@ -214,7 +214,9 @@ static auto SetupCentralWidget(QWidget& fileBrowserWidget, std::shared_ptr<Curre
                      [fileListViewWidget] { fileListViewWidget->GetFileListTableView().resizeColumnsToContents(); });
     QObject::connect(fileListViewWidget->GetModelProvider().lock().get(), &FileBrowserViewModelProvider::rowsInserted,
                      [fileListViewWidget](const QModelIndex&, int first, int) {
-                         if (first < 3) // Resize for the first couple batches of inserted rows
+                         if (first < 1)
+                             // Resize for the first batch of inserted rows,
+                             // because resizing the columns is expensive, and the view starts at the top
                              fileListViewWidget->GetFileListTableView().resizeColumnsToContents();
                      });
 

--- a/TabsPls_Qt/LightSpeedFileExplorer/LightSpeedFileExplorer_en_GB.ts
+++ b/TabsPls_Qt/LightSpeedFileExplorer/LightSpeedFileExplorer_en_GB.ts
@@ -4,28 +4,28 @@
 <context>
     <name>FileBrowserWidget</name>
     <message>
-        <location filename="FileBrowserWidget.cpp" line="311"/>
-        <location filename="FileBrowserWidget.cpp" line="312"/>
+        <location filename="FileBrowserWidget.cpp" line="313"/>
+        <location filename="FileBrowserWidget.cpp" line="314"/>
         <source>New Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="FileBrowserWidget.cpp" line="311"/>
+        <location filename="FileBrowserWidget.cpp" line="313"/>
         <source>New folder name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="FileBrowserWidget.cpp" line="320"/>
+        <location filename="FileBrowserWidget.cpp" line="322"/>
         <source>Create new folder failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="FileBrowserWidget.cpp" line="366"/>
+        <location filename="FileBrowserWidget.cpp" line="368"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="FileBrowserWidget.cpp" line="371"/>
+        <location filename="FileBrowserWidget.cpp" line="373"/>
         <source>Unable to change directory</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Performance was suffering greatly because reapplying the filter to all rows on every row insert is too expensive