### PR TITLE
Give the flattened model its own threadpool

### DIFF
--- a/TabsPls_Qt/LightSpeedFileExplorer/FlattenedDirectoryViewModel.hpp
+++ b/TabsPls_Qt/LightSpeedFileExplorer/FlattenedDirectoryViewModel.hpp
@@ -7,6 +7,7 @@
 
 #include <QAbstractTableModel>
 #include <QIcon>
+#include <QThreadPool>
 
 #include "DirectoryChanger.hpp"
 #include "FileEntryModel.hpp"
@@ -50,6 +51,7 @@ class FlattenedDirectoryViewModel final : public QAbstractTableModel, public Dir
     FileRetrievalRunnableContainer::NameSortedModelSet m_modelEntries;
     QStyle& m_styleProvider;
     QIcon m_defaultFileIcon;
+    mutable QThreadPool m_threadPool;
     std::shared_ptr<FileRetrievalByDispatch::DirectoryReadDispatcher> m_dispatch;
     std::shared_ptr<FileRetrievalRunnableProvider> m_runnableProvider;
 


### PR DESCRIPTION
This makes it easy to cancel runnables that aren't yet being executed because you may assume the threadpool contains only the flat model's runnables