### PR TITLE
Fix bug where the EXECUTABLE argument was passed in the wrong encoding

### DIFF
--- a/TabsPls_Qt/LightSpeedFileExplorer/EscapePod/main.cpp
+++ b/TabsPls_Qt/LightSpeedFileExplorer/EscapePod/main.cpp
@@ -14,6 +14,9 @@ int main(int argc, char** argv) {
 
     QApplication app(argc, argv);
 
+    // EXECUTABLE argument should be a fully encoded URL (preferrably made with QUrl::toEncoded())
+    // WORKING_DIR argument should be a system native encoded string
+
     const std::string executable(argv[1]);
     const std::string workingDir(argv[2]);
 
@@ -23,8 +26,13 @@ int main(int argc, char** argv) {
     }
 
     try {
-        std::filesystem::current_path(workingDir.c_str());
-        QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(executable)));
+        std::filesystem::current_path(workingDir);
+        const auto url = QUrl::fromEncoded(executable.c_str());
+        if (!url.isValid()) {
+            std::cerr << "No valid url could be made with the given EXECUTABLE argument: " << executable << std::endl;
+            return -1;
+        }
+        QDesktopServices::openUrl(url);
     } catch (std::filesystem::filesystem_error& e) {
         std::cerr << "Error setting current path: " << e.what() << std::endl;
     }

--- a/TabsPls_Qt/LightSpeedFileExplorer/EscapePodLauncher.cpp
+++ b/TabsPls_Qt/LightSpeedFileExplorer/EscapePodLauncher.cpp
@@ -12,7 +12,7 @@ namespace EscapePodLauncher {
 void LaunchUrlInWorkingDirectory(const QUrl& url, const FileSystem::Directory& workingDir) {
     const auto workingDirQString = FileSystem::StringConversion::FromRawPath(workingDir.path());
     const int status =
-        QProcess::execute(QString("EscapePod"), QStringList::fromVector({url.toString(), workingDirQString}));
+        QProcess::execute(QString("EscapePod"), QStringList::fromVector({url.toEncoded(), workingDirQString}));
 
     if (status != 0)
         qDebug() << "Something went wrong launching url " << url.toString() << " in directory " << workingDirQString;


### PR DESCRIPTION
Would for instance happen on Windows (no native utf-8), and launching a file containing 'é', the url would not be launched and instead there would be a ShellError in the Debug output.