### PR TITLE
Fix bug in ExtractAssociatedIconW usage

### DIFF
--- a/TabsPls_Qt/LightSpeedFileExplorer/TabsPls_WinIconExtract/WinIconExtract/WinIconExtract.cpp
+++ b/TabsPls_Qt/LightSpeedFileExplorer/TabsPls_WinIconExtract/WinIconExtract/WinIconExtract.cpp
@@ -1,6 +1,9 @@
 #include <WinIconExtract.hpp>
 
+#include <array>
 #include <iostream>
+
+#include <string.h>
 
 #include <QtWinExtras>
 
@@ -18,8 +21,16 @@ void InitThread() {
 std::optional<QPixmap> IconInfoAsPixmap(const std::wstring& path) {
     QString sanitizedPath = QString::fromStdWString(path);
     sanitizedPath.replace("/", "\\");
+
+    std::array<wchar_t, MAX_PATH> pathBuffer{};
+    const auto sanitizedPathWString = sanitizedPath.toStdWString();
+    const auto result = wcscpy_s(pathBuffer.data(), pathBuffer.size(), sanitizedPathWString.c_str());
+    if (result != 0) {
+        return {};
+    }
+
     WORD index = 0;
-    auto hIcon = ExtractAssociatedIconW(0, (LPWSTR)sanitizedPath.toStdWString().c_str(), &index);
+    auto hIcon = ExtractAssociatedIconW(0, (LPWSTR)pathBuffer.data(), &index);
     if (hIcon != 0) {
         auto pixmap = QtWin::fromHICON(hIcon);
         DestroyIcon(hIcon);


### PR DESCRIPTION
The path parameter should've been a buffer, as this is an output parameter as well as input This solves crashes when for example, the current directory is "\"